### PR TITLE
Use quotes to escape the Solr special characters

### DIFF
--- a/source/TraktScrobble.ts
+++ b/source/TraktScrobble.ts
@@ -332,7 +332,8 @@ export default class TraktScrobble {
   }
 
   private async _search(type: 'movie' | 'show', title: string): Promise<Array<ITraktSearchResult> | null> {
-    const searchResponse = await this._client.search(type, title);
+    const escapedTitle = `\"${title}\"`
+    const searchResponse = await this._client.search(type, escapedTitle);
     if (this._handleError(searchResponse)) {
       return null;
     }


### PR DESCRIPTION
Fixes #4 

Here is a test when watching S01E09:

![image](https://user-images.githubusercontent.com/11861253/71375660-ceedb700-259d-11ea-9137-85bb51725c87.png)

Here is what Trakt sees when I'm watching S01E01:

![image](https://user-images.githubusercontent.com/11861253/71397542-a517ad00-25fc-11ea-8b11-d949b83482a9.png)
